### PR TITLE
[job-dsl] add missing triggers to the job dsl

### DIFF
--- a/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/dsl/GitHubPRJobDslExtension.java
+++ b/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/dsl/GitHubPRJobDslExtension.java
@@ -25,6 +25,8 @@ public class GitHubPRJobDslExtension extends ContextExtensionPoint {
 
         GitHubPRTrigger trigger = new GitHubPRTrigger(context.cron(), context.mode(), context.events());
         trigger.setPreStatus(context.isSetPreStatus());
+        trigger.setCancelQueued(context.isSetCancelQueued());
+        trigger.setSkipFirstRun(context.isSetSkipFirstRun());
         return trigger;
     }
 

--- a/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/dsl/GitHubPRJobDslExtension.java
+++ b/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/dsl/GitHubPRJobDslExtension.java
@@ -25,8 +25,7 @@ public class GitHubPRJobDslExtension extends ContextExtensionPoint {
 
         GitHubPRTrigger trigger = new GitHubPRTrigger(context.cron(), context.mode(), context.events());
         trigger.setPreStatus(context.isSetPreStatus());
-        trigger.setCancelQueued(context.isSetCancelQueued());
-        trigger.setSkipFirstRun(context.isSetSkipFirstRun());
+        trigger.setCancelQueued(context.isCancelQueued());
         return trigger;
     }
 

--- a/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/dsl/context/GitHubPRTriggerDslContext.java
+++ b/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/dsl/context/GitHubPRTriggerDslContext.java
@@ -16,8 +16,7 @@ public class GitHubPRTriggerDslContext implements Context {
     private String cron = "H/5 * * * *";
     private GitHubPRTriggerMode mode = GitHubPRTriggerMode.CRON;
     private boolean setPreStatus;
-    private boolean setCancelQueued;
-    private boolean setSkipFirstRun;
+    private boolean cancelQueued;
     private List<GitHubPREvent> events = new ArrayList<>();
 
     public void cron(String cron) {
@@ -35,12 +34,8 @@ public class GitHubPRTriggerDslContext implements Context {
         setPreStatus = true;
     }
 
-    public void setCancelQueued() {
-        setCancelQueued = true;
-    }
-
-    public void setSkipFirstRun() {
-        setSkipFirstRun = true;
+    public void cancelQueued() {
+        cancelQueued = true;
     }
 
     public void events(Runnable closure) {
@@ -62,12 +57,8 @@ public class GitHubPRTriggerDslContext implements Context {
         return setPreStatus;
     }
 
-    public boolean isSetCancelQueued() {
-        return setCancelQueued;
-    }
-
-    public boolean isSetSkipFirstRun() {
-        return setSkipFirstRun;
+    public boolean isCancelQueued() {
+        return cancelQueued;
     }
 
 

--- a/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/dsl/context/GitHubPRTriggerDslContext.java
+++ b/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/dsl/context/GitHubPRTriggerDslContext.java
@@ -16,6 +16,8 @@ public class GitHubPRTriggerDslContext implements Context {
     private String cron = "H/5 * * * *";
     private GitHubPRTriggerMode mode = GitHubPRTriggerMode.CRON;
     private boolean setPreStatus;
+    private boolean setCancelQueued;
+    private boolean setSkipFirstRun;
     private List<GitHubPREvent> events = new ArrayList<>();
 
     public void cron(String cron) {
@@ -31,6 +33,14 @@ public class GitHubPRTriggerDslContext implements Context {
 
     public void setPreStatus() {
         setPreStatus = true;
+    }
+
+    public void setCancelQueued() {
+        setCancelQueued = true;
+    }
+
+    public void setSkipFirstRun() {
+        setSkipFirstRun = true;
     }
 
     public void events(Runnable closure) {
@@ -51,6 +61,15 @@ public class GitHubPRTriggerDslContext implements Context {
     public boolean isSetPreStatus() {
         return setPreStatus;
     }
+
+    public boolean isSetCancelQueued() {
+        return setCancelQueued;
+    }
+
+    public boolean isSetSkipFirstRun() {
+        return setSkipFirstRun;
+    }
+
 
     public List<GitHubPREvent> events() {
         return events;

--- a/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/dsl/context/GitHubPRTriggerModeDslContext.java
+++ b/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/dsl/context/GitHubPRTriggerModeDslContext.java
@@ -17,6 +17,10 @@ public class GitHubPRTriggerModeDslContext implements Context {
         mode = GitHubPRTriggerMode.HEAVY_HOOKS;
     }
 
+    public void heavyHooksCron() {
+        mode = GitHubPRTriggerMode.HEAVY_HOOKS_CRON;
+    }
+
     public GitHubPRTriggerMode mode() {
         return mode;
     }

--- a/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/dsl/context/events/GitHubPREventsDslContext.java
+++ b/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/dsl/context/events/GitHubPREventsDslContext.java
@@ -2,8 +2,17 @@ package org.jenkinsci.plugins.github.pullrequest.dsl.context.events;
 
 import javaposse.jobdsl.dsl.Context;
 import org.jenkinsci.plugins.github.pullrequest.events.GitHubPREvent;
+import org.jenkinsci.plugins.github.pullrequest.GitHubPRLabel;
 import org.jenkinsci.plugins.github.pullrequest.events.impl.GitHubPRCloseEvent;
+import org.jenkinsci.plugins.github.pullrequest.events.impl.GitHubPRCommentEvent;
 import org.jenkinsci.plugins.github.pullrequest.events.impl.GitHubPRCommitEvent;
+import org.jenkinsci.plugins.github.pullrequest.events.impl.GitHubPRDescriptionEvent;
+import org.jenkinsci.plugins.github.pullrequest.events.impl.GitHubPRLabelAddedEvent;
+import org.jenkinsci.plugins.github.pullrequest.events.impl.GitHubPRLabelExistsEvent;
+import org.jenkinsci.plugins.github.pullrequest.events.impl.GitHubPRLabelNotExistsEvent;
+import org.jenkinsci.plugins.github.pullrequest.events.impl.GitHubPRLabelPatternExistsEvent;
+import org.jenkinsci.plugins.github.pullrequest.events.impl.GitHubPRLabelRemovedEvent;
+import org.jenkinsci.plugins.github.pullrequest.events.impl.GitHubPRNonMergeableEvent;
 import org.jenkinsci.plugins.github.pullrequest.events.impl.GitHubPROpenEvent;
 
 import java.util.ArrayList;
@@ -25,6 +34,54 @@ public class GitHubPREventsDslContext implements Context {
 
     public void commit() {
         events.add(new GitHubPRCommitEvent());
+    }
+
+    public void commented(String comment) {
+        events.add(new GitHubPRCommentEvent(comment));
+    }
+
+    public void skipDescription(String skipMsg) {
+        events.add(new GitHubPRDescriptionEvent(skipMsg));
+    }
+
+    public void labelAdded(String label) {
+        events.add(new GitHubPRLabelAddedEvent(new GitHubPRLabel(label)));
+    }
+
+    public void labelExists(String label) {
+        events.add(new GitHubPRLabelExistsEvent(new GitHubPRLabel(label), false));
+    }
+
+    public void skipLabelExists(String label) {
+        events.add(new GitHubPRLabelExistsEvent(new GitHubPRLabel(label), true));
+    }
+
+    public void labelNotExists(String label) {
+        events.add(new GitHubPRLabelNotExistsEvent(new GitHubPRLabel(label), false));
+    }
+
+    public void skipLabelNotExists(String label) {
+        events.add(new GitHubPRLabelNotExistsEvent(new GitHubPRLabel(label), true));
+    }
+
+    public void labelMatchPattern(String pattern) {
+        events.add(new GitHubPRLabelPatternExistsEvent(new GitHubPRLabel(pattern), false));
+    }
+
+    public void skipLabelMatchPattern(String pattern) {
+        events.add(new GitHubPRLabelPatternExistsEvent(new GitHubPRLabel(pattern), true));
+    }
+
+    public void labelRemoved(String label) {
+        events.add(new GitHubPRLabelRemovedEvent(new GitHubPRLabel(label)));
+    }
+
+    public void nonMergeable() {
+        events.add(new GitHubPRNonMergeableEvent(false));
+    }
+
+    public void skipNonMergeable() {
+        events.add(new GitHubPRNonMergeableEvent(true));
     }
 
     public List<GitHubPREvent> events() {

--- a/github-pullrequest-plugin/src/test/java/org/jenkinsci/plugins/github/pullrequest/dsl/DslIntegrationTest.java
+++ b/github-pullrequest-plugin/src/test/java/org/jenkinsci/plugins/github/pullrequest/dsl/DslIntegrationTest.java
@@ -69,8 +69,11 @@ public class DslIntegrationTest {
 
         Collection<Trigger<?>> triggers = generated.getTriggers().values();
         assertThat("Should add trigger", triggers, hasSize(1));
-        Object trigger = triggers.toArray()[0];
+        GitHubPRTrigger trigger = (GitHubPRTrigger)triggers.toArray()[0];
         assertThat("Should add trigger of GHPR class", trigger, instanceOf(GitHubPRTrigger.class));
+        assertThat("Should have pre status", trigger.isPreStatus(), equalTo(true));
+        assertThat("Should have cancel queued", trigger.isCancelQueued(), equalTo(true));
+        assertThat("Should have skip first run", trigger.isSkipFirstRun(), equalTo(true));
         assertThat("Should add events", ((GitHubPRTrigger) trigger).getEvents(), hasSize(15));
         assertThat("Should set mode", ((GitHubPRTrigger) trigger).getTriggerMode(), equalTo(HEAVY_HOOKS_CRON));
     }

--- a/github-pullrequest-plugin/src/test/java/org/jenkinsci/plugins/github/pullrequest/dsl/DslIntegrationTest.java
+++ b/github-pullrequest-plugin/src/test/java/org/jenkinsci/plugins/github/pullrequest/dsl/DslIntegrationTest.java
@@ -23,7 +23,7 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.jenkinsci.plugins.github.pullrequest.GitHubPRTriggerMode.HEAVY_HOOKS;
+import static org.jenkinsci.plugins.github.pullrequest.GitHubPRTriggerMode.HEAVY_HOOKS_CRON;
 import static org.junit.Assert.assertThat;
 
 public class DslIntegrationTest {
@@ -71,7 +71,7 @@ public class DslIntegrationTest {
         assertThat("Should add trigger", triggers, hasSize(1));
         Object trigger = triggers.toArray()[0];
         assertThat("Should add trigger of GHPR class", trigger, instanceOf(GitHubPRTrigger.class));
-        assertThat("Should add events", ((GitHubPRTrigger) trigger).getEvents(), hasSize(2));
-        assertThat("Should set mode", ((GitHubPRTrigger) trigger).getTriggerMode(), equalTo(HEAVY_HOOKS));
+        assertThat("Should add events", ((GitHubPRTrigger) trigger).getEvents(), hasSize(15));
+        assertThat("Should set mode", ((GitHubPRTrigger) trigger).getTriggerMode(), equalTo(HEAVY_HOOKS_CRON));
     }
 }

--- a/github-pullrequest-plugin/src/test/java/org/jenkinsci/plugins/github/pullrequest/dsl/DslIntegrationTest.java
+++ b/github-pullrequest-plugin/src/test/java/org/jenkinsci/plugins/github/pullrequest/dsl/DslIntegrationTest.java
@@ -73,7 +73,6 @@ public class DslIntegrationTest {
         assertThat("Should add trigger of GHPR class", trigger, instanceOf(GitHubPRTrigger.class));
         assertThat("Should have pre status", trigger.isPreStatus(), equalTo(true));
         assertThat("Should have cancel queued", trigger.isCancelQueued(), equalTo(true));
-        assertThat("Should have skip first run", trigger.isSkipFirstRun(), equalTo(true));
         assertThat("Should add events", ((GitHubPRTrigger) trigger).getEvents(), hasSize(15));
         assertThat("Should set mode", ((GitHubPRTrigger) trigger).getTriggerMode(), equalTo(HEAVY_HOOKS_CRON));
     }

--- a/github-pullrequest-plugin/src/test/resources/dsl/jobdsl.groovy
+++ b/github-pullrequest-plugin/src/test/resources/dsl/jobdsl.groovy
@@ -3,8 +3,7 @@ freeStyleJob('gh-pull-request') {
     triggers {
         onPullRequest {
             setPreStatus()
-            setCancelQueued()
-            setSkipFirstRun()
+            cancelQueued()
 
             mode {
                 cron()

--- a/github-pullrequest-plugin/src/test/resources/dsl/jobdsl.groovy
+++ b/github-pullrequest-plugin/src/test/resources/dsl/jobdsl.groovy
@@ -4,11 +4,33 @@ freeStyleJob('gh-pull-request') {
         onPullRequest {
             setPreStatus()
             mode {
+                cron()
                 heavyHooks()
+                heavyHooksCron()
             }
             events {
                 opened()
+                closed()
                 commit()
+
+                commented("match the comment")
+                skipDescription("[skip ci]")
+
+                labelAdded("jenkins")
+
+                labelExists("build")
+                skipLabelExists("skip-build")
+
+                labelNotExists("skip-build")
+                skipLabelNotExists("jenkins")
+
+                labelMatchPattern("pattern")
+                skipLabelMatchPattern("pattern")
+
+                labelRemoved("skip-build")
+
+                nonMergeable()
+                skipNonMergeable()
             }
         }
     }

--- a/github-pullrequest-plugin/src/test/resources/dsl/jobdsl.groovy
+++ b/github-pullrequest-plugin/src/test/resources/dsl/jobdsl.groovy
@@ -3,6 +3,9 @@ freeStyleJob('gh-pull-request') {
     triggers {
         onPullRequest {
             setPreStatus()
+            setCancelQueued()
+            setSkipFirstRun()
+
             mode {
                 cron()
                 heavyHooks()


### PR DESCRIPTION
this PR adds some missing triggers to the Job DSL

It introduces two methods for events that are skipable.

It could be done via passing a block and calling skip() inside, but I have no idea how to do that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-integration-plugin/62)
<!-- Reviewable:end -->
