### PR TITLE
Improve support for pipeline/workflow jobs.

### DIFF
--- a/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/GitHubPRCheckName.java
+++ b/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/GitHubPRCheckName.java
@@ -1,0 +1,47 @@
+package org.jenkinsci.plugins.github.pullrequest;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import hudson.Extension;
+import hudson.model.Describable;
+import hudson.model.Descriptor;
+import jenkins.model.Jenkins;
+
+/**
+ * Represents the name of a check on a PR. In the GitHub API, this is referred to as the "context"
+ * of a commit status. This is the identifier used by GitHub to identify this type of check across
+ * different pull requests. For example, this could be "unit-tests" to indicate that the commit
+ * status refers to the outcome of running the unit tests against a particular commit.
+ *
+ * @author Sean Gilhooly
+ */
+public class GitHubPRCheckName implements Describable<GitHubPRCheckName> {
+
+    private String checkName;
+
+    @DataBoundConstructor
+    public GitHubPRCheckName(final String checkName) {
+        this.checkName = checkName;
+    }
+
+    /**
+     * Return the name to use for the commit status context
+     */
+    public String getCheckName() {
+        return checkName;
+    }
+
+    @Override
+    public Descriptor<GitHubPRCheckName> getDescriptor() {
+        return (DescriptorImpl) Jenkins.getInstance().getDescriptor(GitHubPRCheckName.class);
+    }
+
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<GitHubPRCheckName> {
+        @Override
+        public String getDisplayName() {
+            return "Name for pull request status check";
+        }
+    }
+}

--- a/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/GitHubPRTrigger.java
+++ b/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/GitHubPRTrigger.java
@@ -110,7 +110,8 @@ public class GitHubPRTrigger extends Trigger<Job<?, ?>> {
     /**
      * Set PR(commit) status before build. No configurable message for it.
      */
-    private boolean preStatus = false;
+    @CheckForNull
+    private GitHubPRCheckName preStatus;
     private boolean cancelQueued = false;
     private boolean skipFirstRun = false;
     @CheckForNull
@@ -142,7 +143,7 @@ public class GitHubPRTrigger extends Trigger<Job<?, ?>> {
     }
 
     @DataBoundSetter
-    public void setPreStatus(boolean preStatus) {
+    public void setPreStatus(GitHubPRCheckName preStatus) {
         this.preStatus = preStatus;
     }
 
@@ -167,7 +168,7 @@ public class GitHubPRTrigger extends Trigger<Job<?, ?>> {
     }
 
     public boolean isPreStatus() {
-        return preStatus;
+        return preStatus != null;
     }
 
     public boolean isCancelQueued() {
@@ -184,6 +185,10 @@ public class GitHubPRTrigger extends Trigger<Job<?, ?>> {
 
     public List<GitHubPREvent> getEvents() {
         return events;
+    }
+
+    public GitHubPRCheckName getPreStatus() {
+        return preStatus;
     }
 
     public GitHubPRUserRestriction getUserRestriction() {

--- a/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/dsl/GitHubPRJobDslExtension.java
+++ b/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/dsl/GitHubPRJobDslExtension.java
@@ -6,6 +6,8 @@ import javaposse.jobdsl.dsl.helpers.publisher.PublisherContext;
 import javaposse.jobdsl.dsl.helpers.triggers.TriggerContext;
 import javaposse.jobdsl.plugin.ContextExtensionPoint;
 import javaposse.jobdsl.plugin.DslExtensionMethod;
+
+import org.jenkinsci.plugins.github.pullrequest.GitHubPRCheckName;
 import org.jenkinsci.plugins.github.pullrequest.GitHubPRTrigger;
 import org.jenkinsci.plugins.github.pullrequest.dsl.context.GitHubPRTriggerDslContext;
 import org.jenkinsci.plugins.github.pullrequest.dsl.context.publishers.GitHubPRStatusPublisherDslContext;
@@ -24,7 +26,7 @@ public class GitHubPRJobDslExtension extends ContextExtensionPoint {
         executeInContext(closure, context);
 
         GitHubPRTrigger trigger = new GitHubPRTrigger(context.cron(), context.mode(), context.events());
-        trigger.setPreStatus(context.isSetPreStatus());
+        trigger.setPreStatus(context.isSetPreStatus() ? new GitHubPRCheckName("") : null);
         trigger.setCancelQueued(context.isCancelQueued());
         return trigger;
     }

--- a/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/publishers/impl/GitHubPRBuildStatusPublisher.java
+++ b/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/publishers/impl/GitHubPRBuildStatusPublisher.java
@@ -11,7 +11,9 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Publisher;
+
 import org.jenkinsci.plugins.github.pullrequest.GitHubPRCause;
+import org.jenkinsci.plugins.github.pullrequest.GitHubPRCheckName;
 import org.jenkinsci.plugins.github.pullrequest.GitHubPRMessage;
 import org.jenkinsci.plugins.github.pullrequest.GitHubPRTrigger;
 import org.jenkinsci.plugins.github.pullrequest.publishers.GitHubPRAbstractPublisher;
@@ -22,6 +24,7 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.github.GHCommitState;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,6 +36,7 @@ import static org.apache.commons.lang.StringUtils.isEmpty;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.jenkinsci.plugins.github.pullrequest.utils.ObjectsUtil.isNull;
 import static org.jenkinsci.plugins.github.pullrequest.utils.ObjectsUtil.nonNull;
+import static org.jenkinsci.plugins.github.pullrequest.utils.PRHelperFunctions.getCommitStatusContext;
 
 /**
  * Sets build status on GitHub.
@@ -46,6 +50,8 @@ public class GitHubPRBuildStatusPublisher extends GitHubPRAbstractPublisher {
     private GitHubPRMessage statusMsg = new GitHubPRMessage("${GITHUB_PR_COND_REF} run ended");
     private GHCommitState unstableAs = GHCommitState.FAILURE;
     private BuildMessage buildMessage = new BuildMessage();
+    private GitHubPRCheckName customCheck;
+    private CommitState forceStatus;
 
     /**
      * Constructor with defaults. Only for groovy UI.
@@ -66,6 +72,16 @@ public class GitHubPRBuildStatusPublisher extends GitHubPRAbstractPublisher {
         this.buildMessage = buildMessage;
     }
 
+    @DataBoundSetter
+    public void setCustomCheck(GitHubPRCheckName customCheck) {
+        this.customCheck = customCheck;
+    }
+
+    @DataBoundSetter
+    public void setForceStatus(CommitState state) {
+        this.forceStatus = state;
+    }
+
     @Override
     public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull Launcher launcher,
                         @Nonnull TaskListener listener) throws InterruptedException, IOException {
@@ -80,7 +96,7 @@ public class GitHubPRBuildStatusPublisher extends GitHubPRAbstractPublisher {
             return;
         }
 
-        GHCommitState state = getCommitState(run, unstableAs);
+        GHCommitState state = null == forceStatus ? getCommitState(run, unstableAs) : forceStatus.getState();
 
         GitHubPRCause c = run.getCause(GitHubPRCause.class);
 
@@ -97,9 +113,14 @@ public class GitHubPRBuildStatusPublisher extends GitHubPRAbstractPublisher {
             return;
         }
 
+        String stepName = null;
+        if (null != customCheck) {
+            stepName = customCheck.getCheckName();
+        }
+
         try {
             trigger.getRemoteRepo().createCommitStatus(c.getHeadSha(), state, buildUrl, statusMsgValue,
-                    run.getParent().getFullName());
+                   getCommitStatusContext(run.getParent(), stepName));
         } catch (IOException ex) {
             if (nonNull(buildMessage)) {
                 String comment = null;
@@ -136,6 +157,14 @@ public class GitHubPRBuildStatusPublisher extends GitHubPRAbstractPublisher {
         return statusMsg;
     }
 
+    public GitHubPRCheckName getCustomCheck() {
+        return customCheck;
+    }
+
+    public CommitState getForceStatus() {
+        return forceStatus;
+    }
+
     @Override
     public DescriptorImpl getDescriptor() {
         return (DescriptorImpl) super.getDescriptor();
@@ -152,6 +181,34 @@ public class GitHubPRBuildStatusPublisher extends GitHubPRAbstractPublisher {
         @Override
         public String getDisplayName() {
             return "GitHub PR: set PR status";
+        }
+    }
+
+    public static class CommitState extends AbstractDescribableImpl<CommitState> {
+        private GHCommitState state;
+
+        @DataBoundConstructor
+        public CommitState(GHCommitState state) {
+            this.state = state;
+        }
+
+        public CommitState() {
+        }
+
+        public GHCommitState getState() {
+            return state;
+        }
+
+        public void setState(GHCommitState state) {
+            this.state = state;
+        }
+
+        @Extension
+        public static class DescriptorImpl extends Descriptor<CommitState> {
+            @Override
+            public String getDisplayName() {
+                return "Commit status container";
+            }
         }
     }
 

--- a/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/trigger/JobRunnerForCause.java
+++ b/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/trigger/JobRunnerForCause.java
@@ -13,6 +13,7 @@ import hudson.model.ParametersAction;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.Queue;
 import hudson.model.queue.QueueTaskFuture;
+
 import org.jenkinsci.plugins.github.pullrequest.GitHubPRCause;
 import org.jenkinsci.plugins.github.pullrequest.GitHubPRTrigger;
 import org.kohsuke.github.GHCommitState;
@@ -42,6 +43,7 @@ import static org.jenkinsci.plugins.github.pullrequest.data.GitHubPREnv.TRIGGER_
 import static org.jenkinsci.plugins.github.pullrequest.data.GitHubPREnv.TRIGGER_SENDER_EMAIL;
 import static org.jenkinsci.plugins.github.pullrequest.data.GitHubPREnv.URL;
 import static org.jenkinsci.plugins.github.pullrequest.utils.ObjectsUtil.isNull;
+import static org.jenkinsci.plugins.github.pullrequest.utils.PRHelperFunctions.getCommitStatusContext;
 import static org.jenkinsci.plugins.github.util.FluentIterableWrapper.from;
 import static org.jenkinsci.plugins.github.util.JobInfoHelpers.asParameterizedJobMixIn;
 
@@ -85,7 +87,8 @@ public class JobRunnerForCause implements Predicate<GitHubPRCause> {
                                 GHCommitState.PENDING,
                                 null,
                                 sb.toString(),
-                                job.getFullName());
+                                getCommitStatusContext(job,
+                                                       trigger.getPreStatus().getCheckName()));
             }
         } catch (IOException e) {
             LOGGER.error("Can't trigger build ({})", e.getMessage(), e);

--- a/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/utils/PRHelperFunctions.java
+++ b/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/utils/PRHelperFunctions.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.github.pullrequest.utils;
 
 import com.cloudbees.jenkins.GitHubRepositoryName;
+import com.coravy.hudson.plugins.github.GithubProjectProperty;
 import com.google.common.base.Function;
 import org.jenkinsci.plugins.github.util.misc.NullSafeFunction;
 import org.kohsuke.github.GHPullRequest;
@@ -9,9 +10,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+import hudson.model.Job;
 
 /**
  * @author lanwen (Merkushev Kirill)
@@ -25,6 +31,40 @@ public final class PRHelperFunctions {
     public static String asFullRepoName(GitHubRepositoryName repo) {
         checkNotNull(repo, "Can't get full name from null repo name");
         return String.format("%s/%s", repo.getUserName(), repo.getRepositoryName());
+    }
+
+    /**
+     * Generates the name to use for a commit status context. Combines the GitHub
+     * "display name" field with the name provided for the status update action build step
+     * to produce the name to assign to the commit status context (what shows up in GitHub
+     * as the name of the "check").
+     *
+     * Note that either or both the display name or the step name can be empty.
+     * <ul>
+     *     <li>If both are non-empty, the name is the combination of both.</li>
+     *     <li>If only one is non-empty, it is used for the context name.</li>
+     *     <li>If both are empty, the context name will default to the job name.</li>
+     * </ul>
+     */
+    public static String getCommitStatusContext(Job<?, ?> job, @Nullable String stepName) {
+
+        GithubProjectProperty githubSettings = job.getProperty(GithubProjectProperty.class);
+        String jobContext = githubSettings.getDisplayName();
+
+        StringBuilder contextBuilder = new StringBuilder();
+        if (isNotBlank(jobContext)) {
+            contextBuilder.append(jobContext.trim());
+        }
+        if (isNotBlank(stepName)) {
+            if (0 != contextBuilder.length()) {
+                contextBuilder.append('-');
+            }
+            contextBuilder.append(stepName.trim());
+        }
+        if (0 == contextBuilder.length()) {
+            return job.getFullName();
+        }
+        return contextBuilder.toString();
     }
 
     public static Function<Integer, GHPullRequest> fetchRemotePR(final GHRepository ghRepository) {

--- a/github-pullrequest-plugin/src/main/resources/org/jenkinsci/plugins/github/pullrequest/GitHubPRCheckName/config.groovy
+++ b/github-pullrequest-plugin/src/main/resources/org/jenkinsci/plugins/github/pullrequest/GitHubPRCheckName/config.groovy
@@ -1,0 +1,9 @@
+package org.jenkinsci.plugins.github.pullrequest.GitHubPRCheckName
+
+import lib.FormTagLib
+
+def f = namespace(FormTagLib);
+
+f.entry(title: _("Status check name"), field: "checkName", description: "Optional") {
+    f.textbox()
+}

--- a/github-pullrequest-plugin/src/main/resources/org/jenkinsci/plugins/github/pullrequest/GitHubPRCheckName/help-checkName.html
+++ b/github-pullrequest-plugin/src/main/resources/org/jenkinsci/plugins/github/pullrequest/GitHubPRCheckName/help-checkName.html
@@ -1,0 +1,26 @@
+<div>
+    The name of the commit status check displayed in the pull request.
+    The commit's status check name, shown on the pull request, is typically configured
+    with the GitHub plugin. See the 'Advanced' settings of the job's <em>GitHub
+    project</em> option. When that setting is insufficient, a custom name can be specified
+    here to help identify the particular commit status in use. This setting affects the
+    standard GitHub project value by appending custom text to the original name.
+    The final name of the check is created as:
+    <ul>
+        <li>If the job's "<em>GitHub project</em>" setting has a configured "display name"...
+            <ul>
+                <li>Without a custom name: <code>displayName</code></li>
+                <li>With a custom name: <code>displayName-customName</code></li>
+            </ul>
+        </li>
+        <li>If the GitHub project <b>does not have</b> a configured "display name"...
+            <ul>
+                <li>Without a custom name: <code>jobName</code></li>
+                <li>With a custom name: <code>customName</code></li>
+            </ul>
+        </li>
+    </ul>
+
+    Note, if using a custom name, ensure that any other corresponding status updates use
+    the same name to ensure they update the same commit status.
+</div>

--- a/github-pullrequest-plugin/src/main/resources/org/jenkinsci/plugins/github/pullrequest/GitHubPRTrigger/config.groovy
+++ b/github-pullrequest-plugin/src/main/resources/org/jenkinsci/plugins/github/pullrequest/GitHubPRTrigger/config.groovy
@@ -23,10 +23,6 @@ f.block {
                     checkUrl: "'descriptorByName/hudson.triggers.TimerTrigger/checkSpec?value=' + encodeURIComponent(this.value)")
         }
 
-        f.entry(title: "Set status before build", field: "preStatus") {
-            f.checkbox()
-        }
-
         f.entry(title: "Cancel queued builds", field: "cancelQueued") {
             f.checkbox()
         }
@@ -42,6 +38,8 @@ f.block {
                     hasHeader: true
             )
         }
+
+        f.optionalProperty(title: "Set status before build", field: "preStatus")
 
         f.optionalProperty(title: "Experimental: User Restriction", field: "userRestriction")
 

--- a/github-pullrequest-plugin/src/main/resources/org/jenkinsci/plugins/github/pullrequest/builders/GitHubPRStatusBuilder/config.groovy
+++ b/github-pullrequest-plugin/src/main/resources/org/jenkinsci/plugins/github/pullrequest/builders/GitHubPRStatusBuilder/config.groovy
@@ -13,3 +13,4 @@ if (instance == null) {
 f.entry(title: _("Build status message")) {
     f.property(field: "statusMessage")
 }
+f.optionalProperty(title: "Use custom status identifier name", field: "customCheck")

--- a/github-pullrequest-plugin/src/main/resources/org/jenkinsci/plugins/github/pullrequest/publishers/impl/GitHubPRBuildStatusPublisher/CommitState/config.groovy
+++ b/github-pullrequest-plugin/src/main/resources/org/jenkinsci/plugins/github/pullrequest/publishers/impl/GitHubPRBuildStatusPublisher/CommitState/config.groovy
@@ -1,0 +1,11 @@
+package org.jenkinsci.plugins.github.pullrequest.publishers.impl.GitHubPRBuildStatusPublisher.BuildMessage
+
+import lib.FormTagLib;
+
+def f = namespace(FormTagLib);
+
+f.entry(title: _("Commit status"), field: "state") {
+    f.enum() {
+        text(my.name().toLowerCase().capitalize())
+    }
+}

--- a/github-pullrequest-plugin/src/main/resources/org/jenkinsci/plugins/github/pullrequest/publishers/impl/GitHubPRBuildStatusPublisher/CommitState/help-state.html
+++ b/github-pullrequest-plugin/src/main/resources/org/jenkinsci/plugins/github/pullrequest/publishers/impl/GitHubPRBuildStatusPublisher/CommitState/help-state.html
@@ -1,0 +1,3 @@
+<div>
+    Select the value to attach to the commit status.
+</div>

--- a/github-pullrequest-plugin/src/main/resources/org/jenkinsci/plugins/github/pullrequest/publishers/impl/GitHubPRBuildStatusPublisher/config.groovy
+++ b/github-pullrequest-plugin/src/main/resources/org/jenkinsci/plugins/github/pullrequest/publishers/impl/GitHubPRBuildStatusPublisher/config.groovy
@@ -21,6 +21,14 @@ f.entry(title: _("Mark unstable build in GitHub as "), field: "unstableAs") {
     }
 }
 
+f.optionalProperty(title: "Use custom status identifier name", field: "customCheck")
+
 f.optionalProperty(title: "Use messages in case of status setting failure", field: "buildMessage")
 
 f.optionalProperty(title: "Handle publisher errors", field: "errorHandler")
+
+f.optionalProperty(title: "Force specific status", field: "forceStatus") {
+    f.enum() {
+        text(my.name().toLowerCase().capitalize())
+    }
+}

--- a/github-pullrequest-plugin/src/main/resources/org/jenkinsci/plugins/github/pullrequest/publishers/impl/GitHubPRBuildStatusPublisher/help-forceStatus.html
+++ b/github-pullrequest-plugin/src/main/resources/org/jenkinsci/plugins/github/pullrequest/publishers/impl/GitHubPRBuildStatusPublisher/help-forceStatus.html
@@ -1,0 +1,4 @@
+<div>
+    Normally, the commit status will be set to represent the state of the job (pass/fail). Use this
+    option to override that behavior and set the status to a fixed predetermined value.
+</div>

--- a/github-pullrequest-plugin/src/test/java/org/jenkinsci/plugins/github_integration/its/AbstractPRTest.java
+++ b/github-pullrequest-plugin/src/test/java/org/jenkinsci/plugins/github_integration/its/AbstractPRTest.java
@@ -19,6 +19,7 @@ import org.hamcrest.Matchers;
 import org.jenkinsci.plugins.github.GitHubPlugin;
 import org.jenkinsci.plugins.github.config.GitHubPluginConfig;
 import org.jenkinsci.plugins.github.config.GitHubServerConfig;
+import org.jenkinsci.plugins.github.pullrequest.GitHubPRCheckName;
 import org.jenkinsci.plugins.github.pullrequest.GitHubPRPollingLogAction;
 import org.jenkinsci.plugins.github.pullrequest.GitHubPRPullRequest;
 import org.jenkinsci.plugins.github.pullrequest.GitHubPRRepository;
@@ -197,7 +198,7 @@ public abstract class AbstractPRTest {
         gitHubPREvents.add(new GitHubPRCommitEvent());
 
         final GitHubPRTrigger gitHubPRTrigger = new GitHubPRTrigger("", GitHubPRTriggerMode.CRON, gitHubPREvents);
-        gitHubPRTrigger.setPreStatus(true);
+        gitHubPRTrigger.setPreStatus(new GitHubPRCheckName(""));
 
         return gitHubPRTrigger;
     }


### PR DESCRIPTION
Add finer-grained controls over GitHub commit statuses with the ability to:

 * control the ID/name of the commit status context
 * set the commit status to a particular value regardless of the job progress/state

This allows pipeline builds the ability to:

 * Update multiple comit status fields from a single job
 * Set the commit status based on logic from within the script rather than
    inheriting the whole job status

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-integration-plugin/65)
<!-- Reviewable:end -->
