### PR TITLE
set github status to pending with url of the job

### DIFF
--- a/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/trigger/JobRunnerForCause.java
+++ b/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/trigger/JobRunnerForCause.java
@@ -83,7 +83,7 @@ public class JobRunnerForCause implements Predicate<GitHubPRCause> {
                 trigger.getRemoteRepo()
                         .createCommitStatus(cause.getHeadSha(),
                                 GHCommitState.PENDING,
-                                null,
+                                job.getAbsoluteUrl(),
                                 sb.toString(),
                                 job.getFullName());
             }


### PR DESCRIPTION
I really have no idea how to get correct url for a job. 

Mentioned this in https://github.com/jenkinsci/github-integration-plugin/pull/65#issuecomment-205371052

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-integration-plugin/69)
<!-- Reviewable:end -->
