### PR TITLE
Add pipeline step to update commit status of pull request

### DIFF
--- a/github-pullrequest-plugin/pom.xml
+++ b/github-pullrequest-plugin/pom.xml
@@ -121,6 +121,13 @@
             <optional>true</optional>
         </dependency>
 
+        <!-- for pipeline/workflow step extension -->
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-step-api</artifactId>
+            <version>${workflow.version}</version>
+        </dependency>
+
         <!-- workflow for tests -->
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/pipeline/ProjectConfigurationException.java
+++ b/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/pipeline/ProjectConfigurationException.java
@@ -10,4 +10,7 @@ public class ProjectConfigurationException extends Exception {
     public ProjectConfigurationException(String message) {
         super(message);
     }
+    public ProjectConfigurationException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/pipeline/ProjectConfigurationException.java
+++ b/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/pipeline/ProjectConfigurationException.java
@@ -10,6 +10,7 @@ public class ProjectConfigurationException extends Exception {
     public ProjectConfigurationException(String message) {
         super(message);
     }
+
     public ProjectConfigurationException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/pipeline/ProjectConfigurationException.java
+++ b/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/pipeline/ProjectConfigurationException.java
@@ -1,0 +1,13 @@
+package org.jenkinsci.plugins.github.pullrequest.pipeline;
+
+/**
+ * Raised when the project is configured improperly. Certain steps require particular
+ * project properties to be enabled or set. If the step cannot find the setting it
+ * needs it will raise this error to indicate the missing or incorrect attribute.
+ */
+public class ProjectConfigurationException extends Exception {
+
+    public ProjectConfigurationException(String message) {
+        super(message);
+    }
+}

--- a/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/pipeline/SetCommitStatusExecution.java
+++ b/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/pipeline/SetCommitStatusExecution.java
@@ -1,0 +1,133 @@
+package org.jenkinsci.plugins.github.pullrequest.pipeline;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.jenkinsci.plugins.github.pullrequest.utils.ObjectsUtil.isNull;
+import static org.jenkinsci.plugins.github.pullrequest.utils.ObjectsUtil.nonNull;
+
+import org.jenkinsci.plugins.github.pullrequest.GitHubPRCause;
+import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution;
+import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
+import org.kohsuke.github.GHRepository;
+
+import com.cloudbees.jenkins.GitHubRepositoryName;
+import com.coravy.hudson.plugins.github.GithubProjectProperty;
+import com.google.inject.Inject;
+
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import jenkins.model.JenkinsLocationConfiguration;
+
+/**
+ * Pipeline DSL step to update a GitHub commit status for a pull request.
+ */
+public class SetCommitStatusExecution extends AbstractSynchronousNonBlockingStepExecution<Void> {
+
+    /** YYYYMMDD */
+    private static final long serialVersionUID = 20160401L;
+
+    @StepContextParameter
+    private transient Run<?, ?> build;
+
+    @StepContextParameter
+    private transient TaskListener log;
+
+    @Inject
+    private transient SetCommitStatusStep config;
+
+    @Override
+    protected Void run() throws Exception {
+        //
+        // Figure out which GitHub repository to send the request to
+        //
+        checkArgument(nonNull(config.getState()), "Missing required parameter 'state'");
+
+        GHRepository repository = resolveRepository();
+        String statusContext = resolveContext();
+
+        final GitHubPRCause cause = build.getCause(GitHubPRCause.class);
+        if (isNull(cause)) {
+            throw new ProjectConfigurationException("pullRequestSetCommitStatus requires build to be triggered by GitHub Pull Request");
+        }
+        //
+        // Update the commit status
+        //
+        log.getLogger().printf("Setting pull request status %s to %s with message: %s%n",
+                               statusContext,
+                               config.getState(),
+                               config.getMessage());
+        String buildUrl = null;
+        final JenkinsLocationConfiguration globalConfig = JenkinsLocationConfiguration.get();
+        if (nonNull(globalConfig)) {
+            buildUrl = globalConfig.getUrl();
+        }
+        if (isEmpty(buildUrl)) {
+            log.error("Jenkins Location is not configured in system settings. Cannot create a 'details' link.");
+            buildUrl = null;
+        } else {
+            buildUrl += build.getUrl();
+        }
+
+        repository.createCommitStatus(cause.getHeadSha(),
+                                      config.getState(),
+                                      buildUrl,
+                                      config.getMessage(),
+                                      statusContext);
+        return null;
+    }
+
+    /**
+     * Looks up the GitHub repository associated with this build. This expects that the Pull Request
+     * Trigger is configured properly for this project and that it specifies a GitHub project which
+     * has a corresponding "Server" configuration in the global settings (which provides the
+     * necessary credentials).
+     */
+    private GHRepository resolveRepository() throws ProjectConfigurationException {
+        String repositoryURL;
+        //
+        // Use the GitHub repo as defined in the job settings
+        //
+        GithubProjectProperty githubProperty = build.getParent().getProperty(GithubProjectProperty.class);
+        if (isNull(githubProperty) || isBlank(githubProperty.getProjectUrlStr())) {
+            throw new ProjectConfigurationException("pullRequest: GitHub repository not configured for build project");
+        }
+        repositoryURL = githubProperty.getProjectUrlStr();
+
+        GitHubRepositoryName repoName = GitHubRepositoryName.create(repositoryURL);
+        if (isNull(repoName)) {
+            throw new ProjectConfigurationException("Invalid URL \"" + repositoryURL + "\" provided as GitHub project");
+        }
+
+        GHRepository resolvedRepo = repoName.resolveOne();
+        if (isNull(resolvedRepo)) {
+            throw new ProjectConfigurationException("No configuration found for GitHub server at \""
+                                                            + repositoryURL + "\". Check global configuration.");
+        }
+        return resolvedRepo;
+    }
+
+    /**
+     * Determines the commit status "context" to use for the status update. The context appears in
+     * GitHub as a sort of name for the check. It identifies a status check among the other status
+     * checks placed on the same commit.
+     * <p>
+     * The context name is specified as an argument to this step function. If that argument is
+     * omitted, however, it will fall back to the "Display Name" property of the GitHub project
+     * property of the build. Lastly, if that is also omitted, it will simply use the id/name of
+     * the project as the context name.
+     */
+    private String resolveContext() {
+        if (isNotBlank(config.getContext())) {
+            return config.getContext();
+        }
+        GithubProjectProperty githubProperty = build.getParent().getProperty(GithubProjectProperty.class);
+        if (isNull(githubProperty) || isBlank(githubProperty.getDisplayName())) {
+            log.error("Unable to determine commit status context (the check name). "
+                           + "Argument 'context' not provided and no default configured. Using job name as fallback.");
+            return build.getParent().getFullName();
+        }
+        return githubProperty.getDisplayName();
+    }
+}

--- a/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/pipeline/SetCommitStatusExecution.java
+++ b/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/pipeline/SetCommitStatusExecution.java
@@ -49,7 +49,8 @@ public class SetCommitStatusExecution extends AbstractSynchronousNonBlockingStep
 
         final GitHubPRCause cause = build.getCause(GitHubPRCause.class);
         if (isNull(cause)) {
-            throw new ProjectConfigurationException("pullRequestSetCommitStatus requires build to be triggered by GitHub Pull Request");
+            throw new ProjectConfigurationException("pullRequestSetCommitStatus "
+                                + "requires build to be triggered by GitHub Pull Request");
         }
         //
         // Update the commit status

--- a/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/pipeline/SetCommitStatusStep.java
+++ b/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/pipeline/SetCommitStatusStep.java
@@ -17,7 +17,7 @@ import hudson.Extension;
 public class SetCommitStatusStep extends AbstractStepImpl implements Serializable {
 
     /** YYYYMMDD */
-    private static final long serialVersionUID = 20160401L;
+    private static final long serialVersionUID = 1L;
 
     @DataBoundSetter private String context;
 

--- a/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/pipeline/SetCommitStatusStep.java
+++ b/github-pullrequest-plugin/src/main/java/org/jenkinsci/plugins/github/pullrequest/pipeline/SetCommitStatusStep.java
@@ -1,0 +1,73 @@
+package org.jenkinsci.plugins.github.pullrequest.pipeline;
+
+import java.io.Serializable;
+
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.kohsuke.github.GHCommitState;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import hudson.Extension;
+
+/**
+ * Representation of the configuration for the commit status set step. An instance of this class
+ * is made available to the SetCommitStatusExecution object to instruct it on what to do.
+ */
+public class SetCommitStatusStep extends AbstractStepImpl implements Serializable {
+
+    /** YYYYMMDD */
+    private static final long serialVersionUID = 20160401L;
+
+    @DataBoundSetter private String context;
+
+    @DataBoundSetter private GHCommitState state;
+
+    @DataBoundSetter private String message;
+
+    @DataBoundConstructor
+    public SetCommitStatusStep() {
+    }
+
+    /**
+     * The desired context for the status. The context identifies a status value on the commit. For
+     * example, with two status values, one might have a context of "compile" and another
+     * might have one with "tests" to indicate which phase of the build/validation the status
+     * applies to.
+     */
+    public String getContext() {
+        return context;
+    }
+
+    /**
+     * The desired state of the status.
+     */
+    public GHCommitState getState() {
+        return state;
+    }
+
+    /**
+     * The message associated with the status providing some detail for it.
+     */
+    public String getMessage() {
+        return message;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends AbstractStepDescriptorImpl {
+
+        public DescriptorImpl() {
+            super(SetCommitStatusExecution.class);
+        }
+
+        @Override
+        public String getFunctionName() {
+            return "pullRequestSetCommitStatus";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Set GitHub Commit Status";
+        }
+    }
+}

--- a/github-pullrequest-plugin/src/main/resources/org/jenkinsci/plugins/github/pullrequest/pipeline/SetCommitStatusStep/config.groovy
+++ b/github-pullrequest-plugin/src/main/resources/org/jenkinsci/plugins/github/pullrequest/pipeline/SetCommitStatusStep/config.groovy
@@ -1,0 +1,20 @@
+package org.jenkinsci.plugins.github.pullrequest.pipeline.SetCommitStatusStep
+
+import lib.FormTagLib;
+
+def f = namespace(FormTagLib);
+
+
+f.entry(title: _("Status context"), field: "context") {
+    f.textbox()
+}
+
+f.entry(title: _("Status"), field: "state") {
+    f.enum() {
+        text(my.name().toLowerCase().capitalize())
+    }
+}
+
+f.entry(title: _("Status message"), field: "message") {
+    f.textarea()
+}

--- a/github-pullrequest-plugin/src/main/resources/org/jenkinsci/plugins/github/pullrequest/pipeline/SetCommitStatusStep/help-context.html
+++ b/github-pullrequest-plugin/src/main/resources/org/jenkinsci/plugins/github/pullrequest/pipeline/SetCommitStatusStep/help-context.html
@@ -1,0 +1,3 @@
+<div>
+    A string label to differentiate this status from the status of other systems.
+</div>

--- a/github-pullrequest-plugin/src/main/resources/org/jenkinsci/plugins/github/pullrequest/pipeline/SetCommitStatusStep/help-message.html
+++ b/github-pullrequest-plugin/src/main/resources/org/jenkinsci/plugins/github/pullrequest/pipeline/SetCommitStatusStep/help-message.html
@@ -1,0 +1,3 @@
+<div>
+    A short detail message to add to the status
+</div>

--- a/github-pullrequest-plugin/src/main/resources/org/jenkinsci/plugins/github/pullrequest/pipeline/SetCommitStatusStep/help-state.html
+++ b/github-pullrequest-plugin/src/main/resources/org/jenkinsci/plugins/github/pullrequest/pipeline/SetCommitStatusStep/help-state.html
@@ -1,0 +1,3 @@
+<div>
+    State of the status indicating the progress or completion of the check.
+</div>

--- a/github-pullrequest-plugin/src/main/resources/org/jenkinsci/plugins/github/pullrequest/pipeline/SetCommitStatusStep/help.html
+++ b/github-pullrequest-plugin/src/main/resources/org/jenkinsci/plugins/github/pullrequest/pipeline/SetCommitStatusStep/help.html
@@ -1,0 +1,4 @@
+<div>
+    Sets the commit status of the commit that triggered a pull request build. Note that this
+    step can only be used by builds that were triggered by a pull request.
+</div>


### PR DESCRIPTION
This is a far simpler alternative to PR #65. It introduces a new groovy step that can be used in a pipeline/workflow project (https://github.com/jenkinsci/workflow-plugin). 

The step can be used anywhere in the DSL (at the top level, inside a `node` block, etc...) but it does require that the project be set up and configured with the Pull Request Trigger.

For a simplified example, you can do something like this:
```groovy

pullRequestSetCommitStatus state: 'PENDING', context: 'mytests', message: 'Build queued'

try {
    node {
        pullRequestSetCommitStatus state: 'PENDING', context: 'mytests', message: 'Tests running'
        // .. do the build and/or test stuff...
        pullRequestSetCommitStatus state: 'SUCCESS', context: 'mytests', message: 'Tests passed'
    }
}
catch (Exception e) {
    pullRequestSetCommitStatus state: 'FAILURE', context: 'mytests', message: 'Some tests failed'
    throw e
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/github-integration-plugin/71)
<!-- Reviewable:end -->
